### PR TITLE
Updated Video.fps to match API

### DIFF
--- a/Panda/Domain/Video.cs
+++ b/Panda/Domain/Video.cs
@@ -15,7 +15,7 @@ namespace Panda.Domain
         public int? thumbnail_position { get; set; }
         public int? height { get; set; }
         public int? width { get; set; }
-        public int? fps { get; set; }
+        public float? fps { get; set; }
         public int? duration { get; set; }
         public long? file_size { get; set; }
         public DateTime created_at { get; set; }


### PR DESCRIPTION
Not sure if another type is more appropriate, but when using this library with the current API, the fps value in the response was a decimal, rather than the integer the current master specifies. This simple change made the library work.
